### PR TITLE
Fix CurrencyRate.adapters method

### DIFF
--- a/lib/currency_rate.rb
+++ b/lib/currency_rate.rb
@@ -26,7 +26,7 @@ module CurrencyRate
 
   def self.adapters(type)
     Dir[File.join self.root, "lib/adapters/#{type}/*"].map do |file|
-      File.basename(file, ".rb").split('_').map {|w| w.capitalize}.join
+      File.basename(file, ".rb").split('_')[0...-1].map {|w| w.capitalize}.join
     end
   end
 

--- a/spec/lib/synchronizer_spec.rb
+++ b/spec/lib/synchronizer_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe CurrencyRate::Synchronizer do
   describe "#sync!" do
     before do
       @kraken_data = normalized_data_for :kraken
-      @crypto_adapters = ["KrakenAdapter"]
+      @crypto_adapters = ["Kraken"]
       allow(CurrencyRate::KrakenAdapter.instance).to receive(:fetch_rates).and_return(@kraken_data)
       allow(CurrencyRate.configuration).to receive(:crypto_adapters).and_return(@crypto_adapters)
 
       @yahoo_data = normalized_data_for :yahoo
-      @fiat_adapters = ["YahooAdapter"]
+      @fiat_adapters = ["Yahoo"]
       allow(CurrencyRate::YahooAdapter.instance).to receive(:fetch_rates).and_return(@yahoo_data)
       allow(CurrencyRate.configuration).to receive(:fiat_adapters).and_return(@fiat_adapters)
     end


### PR DESCRIPTION
If we don't specify (crypto/fiat) adapters in config then all available adapters are assigned.
The bug was that they had wrong names: ['YahooAdapter', 'FixerAdapter'] while they should be ['Yahoo', 'Fixer'] 